### PR TITLE
Migrate BBN inference from OpenBUGS to PyMC with trace reuse

### DIFF
--- a/Dockers/HybridTool/run_bbn_inference.py
+++ b/Dockers/HybridTool/run_bbn_inference.py
@@ -147,9 +147,9 @@ def get_job_config() -> Dict[str, Any]:
     return config
 
 
-def _pfd_stats(pfd_samples: Any) -> Dict[str, float]:
-    """Compute summary statistics from PFD posterior samples."""
-    values = np.array(pfd_samples).flatten()
+def _var_stats(samples: Any) -> Dict[str, float]:
+    """Compute summary statistics from posterior samples."""
+    values = np.array(samples).flatten()
     return {
         "mean": float(values.mean()),
         "sd": float(values.std()),
@@ -157,6 +157,17 @@ def _pfd_stats(pfd_samples: Any) -> Dict[str, float]:
         "q2_5": float(np.percentile(values, 2.5)),
         "q97_5": float(np.percentile(values, 97.5)),
     }
+
+
+# Variables to include in output
+OUTPUT_VAR_NAMES = [
+    "PFD",
+    "SR_Total_Remained_Defect",
+    "SD_Total_Remained_Defect",
+    "IM_Total_Remained_Defect",
+    "ST_Total_Remained_Defect",
+    "IC_Total_Remained_Defect",
+]
 
 
 def _save_results(config: Dict[str, Any], result_json: Dict[str, Any]) -> str:
@@ -207,9 +218,13 @@ def main():
 
         if config["TEST_MODE"]:
             print("\n[TEST MODE] Skipping computation, using dummy values")
-            pfd_stats = {
-                "mean": 0.0001, "sd": 0.00005,
-                "median": 0.0001, "q2_5": 0.00005, "q97_5": 0.00015,
+            output_stats = {
+                "PFD": {"mean": 0.0001, "sd": 0.00005, "median": 0.0001, "q2_5": 0.00005, "q97_5": 0.00015},
+                "SR_Total_Remained_Defect": {"mean": 7.0, "sd": 4.0, "median": 6.0, "q2_5": 1.0, "q97_5": 16.0},
+                "SD_Total_Remained_Defect": {"mean": 23.0, "sd": 14.0, "median": 20.0, "q2_5": 3.0, "q97_5": 55.0},
+                "IM_Total_Remained_Defect": {"mean": 36.0, "sd": 20.0, "median": 32.0, "q2_5": 8.0, "q97_5": 80.0},
+                "ST_Total_Remained_Defect": {"mean": 24.0, "sd": 13.0, "median": 21.0, "q2_5": 5.0, "q97_5": 55.0},
+                "IC_Total_Remained_Defect": {"mean": 9.0, "sd": 7.0, "median": 7.0, "q2_5": 1.0, "q97_5": 25.0},
             }
             trace_s3_key = None
         else:
@@ -224,9 +239,15 @@ def main():
             )
             print("[STEP 1] Composite model completed")
 
-            # Compute PFD statistics
-            pfd_stats = _pfd_stats(trace.posterior["PFD"])
-            print(f"[STEP 1] PFD mean: {pfd_stats['mean']:.6g}, sd: {pfd_stats['sd']:.6g}")
+            # Compute statistics for all output variables
+            posterior = trace.posterior
+            output_stats = {}
+            for var_name in OUTPUT_VAR_NAMES:
+                if var_name in posterior:
+                    output_stats[var_name] = _var_stats(posterior[var_name])
+                    print(f"[STEP 1] {var_name} mean: {output_stats[var_name]['mean']:.6g}")
+                else:
+                    print(f"[WARN] {var_name} not found in posterior")
 
             # Save trace to S3
             print("\n[STEP 2] Saving trace to S3...")
@@ -236,7 +257,7 @@ def main():
         # Build result JSON
         result_json = {
             "input": input_json,
-            "output": {"PFD": pfd_stats},
+            "output": output_stats,
         }
         s3_location = _save_results(config, result_json)
 

--- a/Dockers/HybridTool/run_bbn_inference.py
+++ b/Dockers/HybridTool/run_bbn_inference.py
@@ -173,7 +173,7 @@ OUTPUT_VAR_NAMES = [
 def _save_results(config: Dict[str, Any], result_json: Dict[str, Any]) -> str:
     """Save JSON results to S3 or locally."""
     job_id = config["JOB_ID"]
-    s3_key = f"results/results-{job_id}.json"
+    s3_key = f"results/bbn/results-{job_id}.json"
     test_output_dir = config["TEST_OUTPUT_DIR"]
 
     if test_output_dir:

--- a/Dockers/HybridTool/run_bbn_inference.py
+++ b/Dockers/HybridTool/run_bbn_inference.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+ECS Fargate Task: BBN Inference (using PyMC MCMC)
+
+Receives attribute state env vars from Lambda,
+runs PyMC composite model, 
+and saves:
+  1. results/results-{JOB_ID}.json
+  2. results/prior-trace-{JOB_ID}.nc — full InferenceData trace for downstream tasks
+
+Environment variables (passed by BayesianStarterLambda as flat key=value):
+- JOB_ID: Job identifier
+- S3_BUCKET: S3 bucket name for results
+- AWS_REGION: AWS region
+- FP_Input: function point value
+- SR_SDP_state, SR_CD_state, ... (all attribute state values)
+- nChains, nIter, nBurnin, nThin: MCMC settings
+- JOBS_TABLE_NAME: (optional) DynamoDB table for job status
+- TEST_MODE: (optional) skip computation, use dummy values
+- TEST_OUTPUT_DIR: (optional) save results locally instead of S3
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import boto3
+import numpy as np
+
+sys.path.insert(0, '/app/server')
+
+from task_common import save_trace_to_s3, update_job_status
+from bbn_inference.runners.composite_model import run_composite_model
+from bbn_inference.data import bayesian_data_from_json
+from bbn_inference.bbn_data_model import BayesianData
+
+# Used to reconstruct sectioned input JSON from flat env vars
+SECTION_KEYS: Dict[str, list] = {
+    "FP": ["FP_Input"],
+    "Requirement Dev": [
+        "SR_SDP_state", "SR_CD_state", "SR_SRS_state", "SR_TA_state", "SR_CA_state",
+        "SR_HA_state", "SR_SA_state", "SR_RA_state", "SR_SQTPG_state", "SR_SATPG_state",
+        "SR_CM_state", "SR_RaA_state",
+    ],
+    "Requirement V&V": [
+        "SR_SVVP_state", "SR_CDE_state", "SR_HRAA_state", "SR_SRE_state", "SR_IAVV_state",
+        "SR_TAVV_state", "SR_CAVV_state", "SR_HAVV_state", "SR_SAVV_state", "SR_RAVV_state",
+        "SR_VVSQTPG_state", "SR_VVSATPG_state", "SR_CMA_state", "SR_RaAVV_state", "SR_VVASRG_state",
+    ],
+    "Design Dev": [
+        "SD_SAD_state", "SD_SDD_state", "SD_TA_state", "SD_CA_state", "SD_HA_state",
+        "SD_SA_state", "SD_RA_state", "SD_SCTPG_state", "SD_SITPG_state", "SD_SCTDG_state",
+        "SD_SITDG_state", "SD_SQTDG_state", "SD_SATDG_state", "SD_CM_state", "SD_RaA_state",
+    ],
+    "Design V&V": [
+        "SD_DE_state", "SD_IAVV_state", "SD_TAVV_state", "SD_CAVV_state", "SD_HAVV_state",
+        "SD_SAVV_state", "SD_RAVV_state", "SD_VVSCTPG_state", "SD_VVSITPG_state",
+        "SD_VVSCTDG_state", "SD_VVSITDG_state", "SD_VVSQTDG_state", "SD_VVSATDG_state",
+        "SD_CMVV_state", "SD_RaAVV_state", "SD_VVASRG_state",
+    ],
+    "Implementation Dev": [
+        "IM_SCaSCDG_state", "IM_TA_state", "IM_CA_state", "IM_HA_state", "IM_SA_state",
+        "IM_RA_state", "IM_CTCG_state", "IM_SITCG_state", "IM_SQTCG_state", "IM_SATCG_state",
+        "IM_SCTPG_state", "IM_SITPG_state", "IM_SQTPG_state", "IM_SCTE_state",
+        "IM_CM_state", "IM_RaA_state",
+    ],
+    "Implementation V&V": [
+        "IM_SCaSCDE_state", "IM_IAVV_state", "IM_TAVV_state", "IM_CAVV_state", "IM_HAVV_state",
+        "IM_SAVV_state", "IM_RAVV_state", "IM_VVSCTCG_state", "IM_VVSITCG_state",
+        "IM_VVSQTCG_state", "IM_VVSATCG_state", "IM_VVSCTPG_state", "IM_VVSITPG_state",
+        "IM_VVSQTPG_state", "IM_VVSCTE_state", "IM_CMVV_state", "IM_RaAVV_state", "IM_VVASRG_state",
+    ],
+    "Test Dev": [
+        "ST_TA_state", "ST_HA_state", "ST_SA_state", "ST_RA_state", "ST_SATE_state",
+        "ST_SAPG_state", "ST_SITE_state", "ST_SQTE_state", "ST_CM_state", "ST_RaA_state",
+    ],
+    "Test V&V": [
+        "ST_TAVV_state", "ST_HAVV_state", "ST_SAVV_state", "ST_RAVV_state", "ST_VVSATE_state",
+        "ST_VVSAPG_state", "ST_VVSITE_state", "ST_VVSQTE_state", "ST_CMVV_state",
+        "ST_RaAVV_state", "ST_VVASRG_state",
+    ],
+    "Installation and Checkout Dev": [
+        "IC_IPG_state", "IC_IaC_state", "IC_HA_state", "IC_SA_state", "IC_RA_state",
+    ],
+    "Installation and Checkout V&V": [
+        "IC_ICAVV_state", "IC_ICVV_state", "IC_HAVV_state", "IC_SAVV_state", "IC_RAVV_state",
+        "IC_VVASRG_state", "IC_VVFRG_state",
+    ],
+}
+
+SETTINGS_KEYS = ["nChains", "nIter", "nBurnin", "nThin", "computeDIC", "includeTraceData"]
+
+
+def build_input_json_from_env() -> Dict[str, Any]:
+    """Reconstruct sectioned input JSON from flat env vars."""
+    input_json: Dict[str, Any] = {}
+
+    for section, keys in SECTION_KEYS.items():
+        section_data = {}
+        for key in keys:
+            val = os.environ.get(key)
+            if val is not None:
+                section_data[key] = val
+        if section_data:
+            input_json[section] = section_data
+
+    settings = {}
+    for key in SETTINGS_KEYS:
+        val = os.environ.get(key)
+        if val is not None:
+            settings[key] = val
+    if settings:
+        input_json["settings"] = settings
+
+    return input_json
+
+
+def get_job_config() -> Dict[str, Any]:
+    config = {
+        "JOB_ID": os.environ.get("JOB_ID"),
+        "S3_BUCKET": os.environ.get("S3_BUCKET"),
+        "AWS_REGION": os.environ.get("AWS_REGION", "ap-northeast-2"),
+        "TEST_MODE": os.environ.get("TEST_MODE", "false").lower() == "true",
+        "TEST_OUTPUT_DIR": os.environ.get("TEST_OUTPUT_DIR"),
+        "JOBS_TABLE_NAME": os.environ.get("JOBS_TABLE_NAME"),
+        "DRAWS": int(os.environ.get("nIter", os.environ.get("DRAWS", "1000"))),
+        "TUNE": int(os.environ.get("nBurnin", os.environ.get("TUNE", "100"))),
+        "CHAINS": int(os.environ.get("nChains", os.environ.get("CHAINS", "4"))),
+        "THIN": int(os.environ.get("nThin", os.environ.get("THIN", "1"))),
+    }
+
+    if not config["JOB_ID"]:
+        raise ValueError("JOB_ID environment variable is required")
+    if not config["S3_BUCKET"]:
+        raise ValueError("S3_BUCKET environment variable is required")
+
+    print(f"[CONFIG] JOB_ID: {config['JOB_ID']}")
+    print(f"[CONFIG] S3_BUCKET: {config['S3_BUCKET']}")
+    print(f"[CONFIG] AWS_REGION: {config['AWS_REGION']}")
+    print(f"[CONFIG] DRAWS: {config['DRAWS']}")
+    print(f"[CONFIG] TUNE: {config['TUNE']}")
+    print(f"[CONFIG] CHAINS: {config['CHAINS']}")
+    print(f"[CONFIG] THIN: {config['THIN']}")
+
+    return config
+
+
+def _pfd_stats(pfd_samples: Any) -> Dict[str, float]:
+    """Compute summary statistics from PFD posterior samples."""
+    values = np.array(pfd_samples).flatten()
+    return {
+        "mean": float(values.mean()),
+        "sd": float(values.std()),
+        "median": float(np.median(values)),
+        "q2_5": float(np.percentile(values, 2.5)),
+        "q97_5": float(np.percentile(values, 97.5)),
+    }
+
+
+def _save_results(config: Dict[str, Any], result_json: Dict[str, Any]) -> str:
+    """Save JSON results to S3 or locally."""
+    job_id = config["JOB_ID"]
+    s3_key = f"results/results-{job_id}.json"
+    test_output_dir = config["TEST_OUTPUT_DIR"]
+
+    if test_output_dir:
+        output_path = Path(test_output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        local_file = output_path / s3_key.replace("/", "_")
+        local_file.write_text(json.dumps(result_json, indent=2), encoding="utf-8")
+        print(f"[TEST MODE] Results saved locally to {local_file}")
+        return str(local_file)
+    else:
+        s3_client = boto3.client('s3', region_name=config["AWS_REGION"])
+        s3_client.put_object(
+            Bucket=config["S3_BUCKET"],
+            Key=s3_key,
+            Body=json.dumps(result_json, indent=2),
+            ContentType="application/json",
+        )
+        print(f"[UPLOAD] Results uploaded to s3://{config['S3_BUCKET']}/{s3_key}")
+        return s3_key
+
+
+def main():
+    print("=" * 80)
+    print("HybridTool BBN Inference - Starting")
+    print("=" * 80)
+
+    dynamodb_client = None
+    config = {}
+
+    try:
+        config = get_job_config()
+        job_id = config["JOB_ID"]
+
+        if config["JOBS_TABLE_NAME"]:
+            dynamodb_client = boto3.client('dynamodb', region_name=config["AWS_REGION"])
+
+        update_job_status(dynamodb_client, config, status='RUNNING')
+
+        # Reconstruct input JSON from flat env vars
+        input_json = build_input_json_from_env()
+        bbn_data: BayesianData = bayesian_data_from_json(input_json)
+
+        if config["TEST_MODE"]:
+            print("\n[TEST MODE] Skipping computation, using dummy values")
+            pfd_stats = {
+                "mean": 0.0001, "sd": 0.00005,
+                "median": 0.0001, "q2_5": 0.00005, "q97_5": 0.00015,
+            }
+            trace_s3_key = None
+        else:
+            # Run composite model
+            print("\n[STEP 1] Running composite model...")
+            trace = run_composite_model(
+                bbn_data,
+                draws=config["DRAWS"],
+                tune=config["TUNE"],
+                chains=config["CHAINS"],
+                thin=config["THIN"],
+            )
+            print("[STEP 1] Composite model completed")
+
+            # Compute PFD statistics
+            pfd_stats = _pfd_stats(trace.posterior["PFD"])
+            print(f"[STEP 1] PFD mean: {pfd_stats['mean']:.6g}, sd: {pfd_stats['sd']:.6g}")
+
+            # Save trace to S3
+            print("\n[STEP 2] Saving trace to S3...")
+            trace_s3_key = save_trace_to_s3(trace, config, job_id)
+            print(f"[STEP 2] Trace saved: {trace_s3_key}")
+
+        # Build result JSON
+        result_json = {
+            "input": input_json,
+            "output": {"PFD": pfd_stats},
+        }
+        s3_location = _save_results(config, result_json)
+
+        s3_key_for_db = s3_location if not config["TEST_OUTPUT_DIR"] else None
+        update_job_status(dynamodb_client, config, status='COMPLETED', s3_key=s3_key_for_db)
+
+        print("\n" + "=" * 80)
+        print("HybridTool BBN Inference - Completed Successfully")
+        print("=" * 80)
+
+        completion_payload = {
+            "status": "completed",
+            "job_id": job_id,
+        }
+        if config["TEST_OUTPUT_DIR"]:
+            completion_payload["local_path"] = s3_location
+        else:
+            completion_payload["s3_location"] = f"s3://{config['S3_BUCKET']}/{s3_location}"
+
+        print(json.dumps(completion_payload))
+
+    except Exception as e:
+        job_id = config.get("JOB_ID", "unknown")
+        error_msg = f"BBN Inference failed: {str(e)}"
+        print(f"\n[ERROR] {error_msg}", file=sys.stderr)
+        update_job_status(dynamodb_client, config, status='FAILED', error_msg=error_msg)
+        print(json.dumps({"status": "failed", "job_id": job_id, "error": error_msg}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Dockers/HybridTool/run_full_analysis.py
+++ b/Dockers/HybridTool/run_full_analysis.py
@@ -224,7 +224,7 @@ def main():
         run_analysis_func=run_full_analysis,
         build_result_json_func=build_result_json,
         build_completion_payload_func=build_completion_payload,
-        s3_key_prefix="full-analysis",
+        s3_key_prefix="full/full-analysis",
         test_mode_dummy_func=get_test_mode_dummy,
     )
 

--- a/Dockers/HybridTool/run_full_analysis.py
+++ b/Dockers/HybridTool/run_full_analysis.py
@@ -9,6 +9,8 @@ Environment variables:
 - FAILURES: Observed number of failures
 - S3_BUCKET: S3 bucket name for results
 - AWS_REGION: AWS region
+- PRIOR_TRACE_S3_KEY: (optional) S3 key of pre-computed prior trace (.nc)
+                      If provided, skips run_composite_model and loads trace from S3.
 
 Output:
 - Uploads JSON file to S3: s3://{S3_BUCKET}/results/full-analysis-{JOB_ID}.json
@@ -23,6 +25,7 @@ from task_common import (
     validate_base_config,
     print_base_config,
     run_task,
+    load_trace_from_s3,
 )
 
 from bbn_inference.sensitivity_analysis import (
@@ -64,6 +67,8 @@ def get_job_config() -> Dict[str, Any]:
     if config["FAILURES"] < 0:
         raise ValueError("FAILURES must be non-negative")
     
+    config["PRIOR_TRACE_S3_KEY"] = os.environ.get("PRIOR_TRACE_S3_KEY")
+
     # Print configuration
     print_base_config(config)
     print(f"[CONFIG] CONFIDENCE_GOAL: {config['CONFIDENCE_GOAL']}")
@@ -76,7 +81,9 @@ def get_job_config() -> Dict[str, Any]:
     print(f"[CONFIG] TUNE: {config['TUNE']}")
     print(f"[CONFIG] CHAINS: {config['CHAINS']}")
     print(f"[CONFIG] THIN: {config['THIN']}")
-    
+    if config["PRIOR_TRACE_S3_KEY"]:
+        print(f"[CONFIG] PRIOR_TRACE_S3_KEY: {config['PRIOR_TRACE_S3_KEY']}")
+
     return config
 
 
@@ -90,9 +97,15 @@ def run_full_analysis(config: Dict[str, Any], bbn_data: Any) -> Dict[str, Any]:
     chains = config["CHAINS"]
     thin = config["THIN"]
     
-    # 1. Generate trace (Prior)
-    print("\n[STEP 1] Generating composite model trace...")
-    trace = run_composite_model(bbn_data, draws=draws, tune=tune, chains=chains, thin=thin)
+    # 1. Get trace (Prior): load from S3 if available, otherwise compute
+    prior_trace_s3_key = config.get("PRIOR_TRACE_S3_KEY")
+    if prior_trace_s3_key:
+        print(f"\n[STEP 1] Loading pre-computed trace from S3: {prior_trace_s3_key}")
+        trace = load_trace_from_s3(config, prior_trace_s3_key)
+        print("[STEP 1] Trace loaded from S3")
+    else:
+        print("\n[STEP 1] Generating composite model trace...")
+        trace = run_composite_model(bbn_data, draws=draws, tune=tune, chains=chains, thin=thin)
     print("[STEP 1] Trace generation completed")
 
     # 2. Sensitivity Analysis: reuse required demand from sensitivity analysis

--- a/Dockers/HybridTool/run_local.py
+++ b/Dockers/HybridTool/run_local.py
@@ -72,8 +72,11 @@ if __name__ == "__main__":
     elif task_type == "update_pfd":
         from run_update_pfd import main
         main()
+    elif task_type == "bbn_inference":
+        from run_bbn_inference import main
+        main()
     else:
         print(f"[ERROR] Unknown TASK_TYPE: {task_type}")
-        print("[ERROR] Valid values: full_analysis, sensitivity_analysis, update_pfd")
+        print("[ERROR] Valid values: full_analysis, sensitivity_analysis, update_pfd, bbn_inference")
         sys.exit(1)
 

--- a/Dockers/HybridTool/run_local.sh
+++ b/Dockers/HybridTool/run_local.sh
@@ -120,12 +120,20 @@ export FAILURES="${FAILURES:-0}"
 export DEMAND_REQUIRED="${DEMAND_REQUIRED:-10000}"
 export S3_BUCKET="${S3_BUCKET:-dummy}"
 export AWS_REGION="${AWS_REGION:-ap-northeast-2}"
-export TEST_MODE="${TEST_MODE:-false}"
+export TEST_MODE="${TEST_MODE:-true}"
 export TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR:-$PROJECT_ROOT/tempDoc/hybrid-tool-test}"
 export DRAWS="${DRAWS:-19500}"
 export TUNE="${TUNE:-500}"
 export CHAINS="${CHAINS:-1}"
 export THIN="${THIN:-1}"
+
+# bbn_inference용 환경 변수 (TASK_TYPE=bbn_inference 시 사용)
+# BayesianPage 폼 데이터 예시값 (실제 값으로 교체 가능)
+export FP_Input="${FP_Input:-50}"
+export nChains="${nChains:-1}"
+export nIter="${nIter:-500}"
+export nBurnin="${nBurnin:-100}"
+export nThin="${nThin:-1}"
 
 # 출력 디렉토리 생성
 mkdir -p "$TEST_OUTPUT_DIR"

--- a/Dockers/HybridTool/run_sensitivity_analysis.py
+++ b/Dockers/HybridTool/run_sensitivity_analysis.py
@@ -21,6 +21,7 @@ from task_common import (
     validate_base_config,
     print_base_config,
     run_task,
+    load_trace_from_s3,
 )
 
 from bbn_inference.sensitivity_analysis import (

--- a/Dockers/HybridTool/run_sensitivity_analysis.py
+++ b/Dockers/HybridTool/run_sensitivity_analysis.py
@@ -157,7 +157,7 @@ def main():
         run_analysis_func=run_sensitivity_analysis,
         build_result_json_func=build_result_json,
         build_completion_payload_func=build_completion_payload,
-        s3_key_prefix="sensitivity-analysis",
+        s3_key_prefix="sensitivity/sensitivity-analysis",
         test_mode_dummy_func=get_test_mode_dummy,
     )
 

--- a/Dockers/HybridTool/run_sensitivity_analysis.py
+++ b/Dockers/HybridTool/run_sensitivity_analysis.py
@@ -8,6 +8,8 @@ Environment variables:
 - CONFIDENCE_GOAL: Target confidence level
 - S3_BUCKET: S3 bucket name for results
 - AWS_REGION: AWS region
+- PRIOR_TRACE_S3_KEY: (optional) S3 key of pre-computed prior trace (.nc)
+                      If provided, skips run_composite_model and loads trace from S3.
 
 Output:
 - Uploads JSON to S3: s3://{S3_BUCKET}/results/sensitivity-analysis-{JOB_ID}.json
@@ -47,6 +49,8 @@ def get_job_config() -> Dict[str, Any]:
     if config["CONFIDENCE_GOAL"] > 1.0:
         raise ValueError("CONFIDENCE_GOAL must be between 0 and 1 (e.g., 0.95)")
     
+    config["PRIOR_TRACE_S3_KEY"] = os.environ.get("PRIOR_TRACE_S3_KEY")
+
     # Print configuration
     print_base_config(config)
     print(f"[CONFIG] CONFIDENCE_GOAL: {config['CONFIDENCE_GOAL']}")
@@ -54,7 +58,9 @@ def get_job_config() -> Dict[str, Any]:
     print(f"[CONFIG] TUNE: {config['TUNE']}")
     print(f"[CONFIG] CHAINS: {config['CHAINS']}")
     print(f"[CONFIG] THIN: {config['THIN']}")
-    
+    if config["PRIOR_TRACE_S3_KEY"]:
+        print(f"[CONFIG] PRIOR_TRACE_S3_KEY: {config['PRIOR_TRACE_S3_KEY']}")
+
     return config
 
 
@@ -67,10 +73,16 @@ def run_sensitivity_analysis(config: Dict[str, Any], bbn_data: Any) -> Dict[str,
     chains = config["CHAINS"]
     thin = config["THIN"]
     
-    # 1. Generate trace (Prior)
-    print("\n[STEP 1] Generating composite model trace...")
-    trace = run_composite_model(bbn_data, draws=draws, tune=tune, chains=chains, thin=thin)
-    print("[STEP 1] Trace generation completed")
+    # 1. Get trace (Prior): load from S3 if available, otherwise compute
+    prior_trace_s3_key = config.get("PRIOR_TRACE_S3_KEY")
+    if prior_trace_s3_key:
+        print(f"\n[STEP 1] Loading pre-computed trace from S3: {prior_trace_s3_key}")
+        trace = load_trace_from_s3(config, prior_trace_s3_key)
+        print("[STEP 1] Trace loaded from S3")
+    else:
+        print("\n[STEP 1] Generating composite model trace...")
+        trace = run_composite_model(bbn_data, draws=draws, tune=tune, chains=chains, thin=thin)
+        print("[STEP 1] Trace generation completed")
 
     # 2. Sensitivity Analysis & Prior Metrics
     print("\n[STEP 2] Running sensitivity analysis...")

--- a/Dockers/HybridTool/run_update_pfd.py
+++ b/Dockers/HybridTool/run_update_pfd.py
@@ -162,7 +162,7 @@ def main():
         run_analysis_func=calculate_pfd_metrics,
         build_result_json_func=build_result_json,
         build_completion_payload_func=build_completion_payload,
-        s3_key_prefix="update-pfd",
+        s3_key_prefix="full/update-pfd",
         test_mode_dummy_func=get_test_mode_dummy,
     )
 

--- a/Dockers/HybridTool/task_common.py
+++ b/Dockers/HybridTool/task_common.py
@@ -8,6 +8,7 @@ Shared functions used across all task types (sensitivity_analysis, update_pfd, f
 import os
 import sys
 import json
+import tempfile
 from pathlib import Path
 from typing import Dict, Any, Tuple, Optional, Callable
 import boto3
@@ -172,8 +173,59 @@ def upload_results_to_s3(
         return s3_key
 
 
+def save_trace_to_s3(trace: Any, config: Dict[str, Any], job_id: str) -> str:
+    """Save InferenceData trace to S3 as NetCDF (.nc) file"""
+    import arviz as az
+
+    s3_key = f"results/prior-trace-{job_id}.nc"
+    s3_bucket = config["S3_BUCKET"]
+    aws_region = config["AWS_REGION"]
+    test_output_dir = config["TEST_OUTPUT_DIR"]
+
+    with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        az.to_netcdf(trace, tmp_path)
+
+        if test_output_dir:
+            output_path = Path(test_output_dir)
+            output_path.mkdir(parents=True, exist_ok=True)
+            local_file = output_path / s3_key.replace("/", "_")
+            import shutil
+            shutil.copy(tmp_path, local_file)
+            print(f"[TEST MODE] Trace saved locally to {local_file}")
+            return str(local_file)
+        else:
+            s3_client = boto3.client('s3', region_name=aws_region)
+            s3_client.upload_file(tmp_path, s3_bucket, s3_key)
+            print(f"[UPLOAD] Trace uploaded to s3://{s3_bucket}/{s3_key}")
+            return s3_key
+    finally:
+        os.unlink(tmp_path)
+
+
+def load_trace_from_s3(config: Dict[str, Any], trace_s3_key: str) -> Any:
+    """Load InferenceData trace from S3 NetCDF (.nc) file"""
+    import arviz as az
+
+    s3_bucket = config["S3_BUCKET"]
+    aws_region = config["AWS_REGION"]
+
+    with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        s3_client = boto3.client('s3', region_name=aws_region)
+        s3_client.download_file(s3_bucket, trace_s3_key, tmp_path)
+        print(f"[DOWNLOAD] Trace downloaded from s3://{s3_bucket}/{trace_s3_key}")
+        return az.from_netcdf(tmp_path)
+    finally:
+        os.unlink(tmp_path)
+
+
 def handle_error_and_exit(
-    e: Exception, 
+    e: Exception,
     config: Dict[str, Any], 
     dynamodb_client: Any,
     task_name: str

--- a/Dockers/HybridTool/task_common.py
+++ b/Dockers/HybridTool/task_common.py
@@ -219,7 +219,14 @@ def load_trace_from_s3(config: Dict[str, Any], trace_s3_key: str) -> Any:
         s3_client = boto3.client('s3', region_name=aws_region)
         s3_client.download_file(s3_bucket, trace_s3_key, tmp_path)
         print(f"[DOWNLOAD] Trace downloaded from s3://{s3_bucket}/{trace_s3_key}")
-        return az.from_netcdf(tmp_path)
+        trace = az.from_netcdf(tmp_path)
+        # Force eager loading before deleting the temp file
+        # (az.from_netcdf uses xarray lazy loading by default)
+        for group_name in trace._groups:
+            group = getattr(trace, group_name, None)
+            if group is not None:
+                group.load()
+        return trace
     finally:
         os.unlink(tmp_path)
 

--- a/Dockers/HybridTool/task_common.py
+++ b/Dockers/HybridTool/task_common.py
@@ -177,7 +177,7 @@ def save_trace_to_s3(trace: Any, config: Dict[str, Any], job_id: str) -> str:
     """Save InferenceData trace to S3 as NetCDF (.nc) file"""
     import arviz as az
 
-    s3_key = f"results/prior-trace-{job_id}.nc"
+    s3_key = f"results/bbn/prior-trace-{job_id}.nc"
     s3_bucket = config["S3_BUCKET"]
     aws_region = config["AWS_REGION"]
     test_output_dir = config["TEST_OUTPUT_DIR"]

--- a/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
+++ b/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
@@ -8,7 +8,7 @@ import { useAppSettings } from '../../../shared/hooks/useAppSettings';
 
 // Polling configuration
 const POLL_INTERVAL = 5000; // 5 seconds
-const MAX_WAIT_TIME = 1200000; // 20 minutes (milliseconds)
+const MAX_WAIT_TIME = 7_200_000; // 120 minutes (milliseconds)
 const MAX_ATTEMPTS = 240; // Maximum 240 attempts (20 minutes / 5 seconds)
 
 export default function StatisticalPage() {

--- a/apps/frontend/src/shared/hooks/useSimulation.ts
+++ b/apps/frontend/src/shared/hooks/useSimulation.ts
@@ -79,7 +79,7 @@ export const useSimulation = () => {
     if (jobStatus === 'COMPLETED' && jobId && jobId !== 'local') {
       apiService.getResults(jobId)
         .then(setResults)
-        .catch(() => setError('Failed to fetch final results.'));
+        .catch((err: any) => setError(`Failed to fetch final results: ${err?.message ?? err}`));
     }
   }, [jobStatus, jobId, setResults, setError]);
 

--- a/apps/frontend/src/shared/services/apiService.ts
+++ b/apps/frontend/src/shared/services/apiService.ts
@@ -86,34 +86,26 @@ export const getJobStatus = async (jobId: string) => {
 };
 
 /**
- * Gets the final results for a completed simulation job.
+ * Gets the final results for a completed BBN simulation job.
+ * Fetches from hybrid-tool-results S3 bucket via getResults Lambda.
  * @param jobId - The unique identifier for the job
- * @returns The final JSON results from the S3 file
+ * @returns The final JSON results: { input, output: { PFD: { mean, sd, median, q2_5, q97_5 } } }
  */
 export const getResults = async (jobId: string) => {
-  const urlResponse = await fetch(`${API_BASE_URL}/jobs/${jobId}/results-url`, {
-    method: 'POST',
-    headers: getApiHeaders(),
-  });
-  if (!urlResponse.ok) throw new Error('Could not get results URL.');
-  
-  const { downloadUrl } = await urlResponse.json();
-  
-  const resultsResponse = await fetch(downloadUrl);
-  if (!resultsResponse.ok) throw new Error('Could not download results file from S3.');
-  // Preserve the original JSON text as-is
-  const rawText = await resultsResponse.text();
-  try {
-    const parsed = rawText ? JSON.parse(rawText) : {};
-    // Attach the original raw text so the UI can display it unchanged
-    if (parsed && typeof parsed === 'object') {
-      (parsed as any).__rawText = rawText;
-    }
-    return parsed;
-  } catch {
-    // If parsing fails, return an object containing only the raw text
-    return { __rawText: rawText } as any;
+  const response = await fetch(
+    `${API_BASE_URL_SST}/api/v1/results/${jobId}?type=bbn-inference`,
+    { headers: getApiHeaders() }
+  );
+  if (!response.ok) throw new Error('Could not get results.');
+
+  const wrapper = await response.json();
+  // wrapper = { job_id, status, data: { input, output }, s3_location }
+  const data = wrapper?.data ?? wrapper;
+  const rawText = JSON.stringify(data, null, 2);
+  if (data && typeof data === 'object') {
+    (data as any).__rawText = rawText;
   }
+  return data;
 };
 
 // =======================================================

--- a/aws-configs/hybridTool-task-definition.json
+++ b/aws-configs/hybridTool-task-definition.json
@@ -23,6 +23,14 @@
         {
           "name": "AWS_REGION",
           "value": "${AWS_REGION}"
+        },
+        {
+          "name": "S3_BUCKET",
+          "value": "hybrid-tool-results"
+        },
+        {
+          "name": "JOBS_TABLE_NAME",
+          "value": "BayesianSimulationJobs"
         }
       ]
     }

--- a/lambda/BayesianStarterLambda.ts
+++ b/lambda/BayesianStarterLambda.ts
@@ -29,7 +29,6 @@ const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 // Get AWS resource information from environment variables
 const TABLE_NAME = process.env.JOBS_TABLE_NAME;        // DynamoDB table name (for storing job status)
 const SUBNET_IDS = process.env.SUBNET_IDS;             // VPC subnet IDs (comma-separated)
-const CONTAINER_NAME = process.env.CONTAINER_NAME;     // Container name
 
 // Parse SUBNET_IDS (comma-separated string) and use first subnet
 const SUBNET_ID = SUBNET_IDS ? SUBNET_IDS.split(',')[0].trim() : undefined;
@@ -59,16 +58,18 @@ function getStageFromEvent(event: APIGatewayProxyEvent): string {
 /**
  * Get resource configuration based on stage
  */
-function getResourceConfig(stage: string): { clusterName: string; taskDefinition: string } {
+function getResourceConfig(stage: string): { clusterName: string; taskDefinition: string; containerName: string } {
   if (stage === 'develop') {
     return {
       clusterName: process.env.CLUSTER_NAME_DEV || process.env.CLUSTER_NAME || '',
       taskDefinition: process.env.BBN_TASK_DEFINITION_DEV || process.env.BBN_TASK_DEFINITION || '',
+      containerName: process.env.CONTAINER_NAME_DEV || process.env.CONTAINER_NAME || '',
     };
   } else {
     return {
       clusterName: process.env.CLUSTER_NAME || '',
       taskDefinition: process.env.BBN_TASK_DEFINITION || '',
+      containerName: process.env.CONTAINER_NAME || '',
     };
   }
 }
@@ -81,11 +82,12 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   const resourceConfig = getResourceConfig(stage);
   const clusterName = resourceConfig.clusterName;
   const taskDefinition = resourceConfig.taskDefinition;
-  
-  console.log(`Detected stage: ${stage}, using cluster: ${clusterName}, task: ${taskDefinition}`);
+  const containerName = resourceConfig.containerName;
+
+  console.log(`Detected stage: ${stage}, using cluster: ${clusterName}, task: ${taskDefinition}, container: ${containerName}`);
 
   // 1. Environment variable validation
-  if (!TABLE_NAME || !clusterName || !taskDefinition || !SUBNET_IDS || !SUBNET_ID || !CONTAINER_NAME) {
+  if (!TABLE_NAME || !clusterName || !taskDefinition || !SUBNET_IDS || !SUBNET_ID || !containerName) {
     console.error("Missing required environment variables.");
     return {
       statusCode: 500,
@@ -160,9 +162,10 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
       },
       overrides: {
         containerOverrides: [{
-          name: CONTAINER_NAME,
+          name: containerName,
           environment: [
             { name: "JOB_ID", value: jobId },
+            { name: "TASK_TYPE", value: "bbn_inference" },
             ...formDataEnvironmentVariables
           ],
         }],

--- a/lambda/hybridTool/getResults.py
+++ b/lambda/hybridTool/getResults.py
@@ -148,28 +148,17 @@ def handler(event, context):
         # 기본값은 full-analysis
         result_type = result_type or 'full-analysis'
 
-        # 스테이지 감지: dev는 하위 폴더 분리된 새 버킷, prod는 구버킷
+        # 스테이지 감지 (향후 dev/prod 분기 확장용)
         stage = _get_stage(event)
-        if stage == 'develop':
-            bucket = S3_BUCKET
-            if result_type == 'sensitivity-analysis':
-                s3_key = f"results/sensitivity/sensitivity-analysis-{job_id}.json"
-            elif result_type == 'update-pfd':
-                s3_key = f"results/full/update-pfd-{job_id}.json"
-            elif result_type == 'bbn-inference':
-                s3_key = f"results/bbn/results-{job_id}.json"
-            else:  # full-analysis
-                s3_key = f"results/full/full-analysis-{job_id}.json"
-        else:  # prod — 구버킷, 구경로
-            bucket = S3_BUCKET_PROD
-            if result_type == 'sensitivity-analysis':
-                s3_key = f"results/sensitivity-analysis-{job_id}.json"
-            elif result_type == 'update-pfd':
-                s3_key = f"results/update-pfd-{job_id}.json"
-            elif result_type == 'bbn-inference':
-                s3_key = f"results/results-{job_id}.json"
-            else:  # full-analysis
-                s3_key = f"results/full-analysis-{job_id}.json"
+        bucket = S3_BUCKET  # 현재 dev/prod 모두 hybrid-tool-results 사용
+        if result_type == 'sensitivity-analysis':
+            s3_key = f"results/sensitivity/sensitivity-analysis-{job_id}.json"
+        elif result_type == 'update-pfd':
+            s3_key = f"results/full/update-pfd-{job_id}.json"
+        elif result_type == 'bbn-inference':
+            s3_key = f"results/bbn/results-{job_id}.json"
+        else:  # full-analysis
+            s3_key = f"results/full/full-analysis-{job_id}.json"
 
         print(f"Result type: {result_type}, stage: {stage}, bucket: {bucket}")
         

--- a/lambda/hybridTool/getResults.py
+++ b/lambda/hybridTool/getResults.py
@@ -16,8 +16,19 @@ from datetime import timedelta
 s3_client = boto3.client('s3', region_name=os.environ.get('AWS_REGION', 'ap-northeast-2'))
 
 # 환경 변수
-S3_BUCKET = os.environ.get('S3_BUCKET')
-PRESIGNED_URL_EXPIRY = int(os.environ.get('PRESIGNED_URL_EXPIRY', '3600'))  # 기본 1시간
+S3_BUCKET = os.environ.get('S3_BUCKET')                        # dev 버킷 (hybrid-tool-results)
+S3_BUCKET_PROD = os.environ.get('S3_BUCKET_PROD', S3_BUCKET)  # prod 버킷 (bayesian-simulation-results-bucket)
+PRESIGNED_URL_EXPIRY = int(os.environ.get('PRESIGNED_URL_EXPIRY', '3600'))
+
+
+def _get_stage(event: dict) -> str:
+    stage = (event.get('requestContext') or {}).get('stage', '')
+    if stage:
+        return stage
+    path = event.get('path', '')
+    if path.startswith('/develop/'):
+        return 'develop'
+    return 'prod'
 
 
 def handler(event, context):
@@ -136,26 +147,40 @@ def handler(event, context):
         
         # 기본값은 full-analysis
         result_type = result_type or 'full-analysis'
-        print(f"Result type: {result_type}, S3_BUCKET: {S3_BUCKET}")
-        
-        # S3 경로 결정 (flattened: results/{endpoint}-{job_id}.json)
-        if result_type == 'sensitivity-analysis':
-            s3_key = f"results/sensitivity/sensitivity-analysis-{job_id}.json"
-        elif result_type == 'update-pfd':
-            s3_key = f"results/full/update-pfd-{job_id}.json"
-        elif result_type == 'bbn-inference':
-            s3_key = f"results/bbn/results-{job_id}.json"
-        else:  # full-analysis
-            s3_key = f"results/full/full-analysis-{job_id}.json"
+
+        # 스테이지 감지: dev는 하위 폴더 분리된 새 버킷, prod는 구버킷
+        stage = _get_stage(event)
+        if stage == 'develop':
+            bucket = S3_BUCKET
+            if result_type == 'sensitivity-analysis':
+                s3_key = f"results/sensitivity/sensitivity-analysis-{job_id}.json"
+            elif result_type == 'update-pfd':
+                s3_key = f"results/full/update-pfd-{job_id}.json"
+            elif result_type == 'bbn-inference':
+                s3_key = f"results/bbn/results-{job_id}.json"
+            else:  # full-analysis
+                s3_key = f"results/full/full-analysis-{job_id}.json"
+        else:  # prod — 구버킷, 구경로
+            bucket = S3_BUCKET_PROD
+            if result_type == 'sensitivity-analysis':
+                s3_key = f"results/sensitivity-analysis-{job_id}.json"
+            elif result_type == 'update-pfd':
+                s3_key = f"results/update-pfd-{job_id}.json"
+            elif result_type == 'bbn-inference':
+                s3_key = f"results/results-{job_id}.json"
+            else:  # full-analysis
+                s3_key = f"results/full-analysis-{job_id}.json"
+
+        print(f"Result type: {result_type}, stage: {stage}, bucket: {bucket}")
         
         print(f"Checking S3 key: {s3_key}")
         
         # Lambda에서 S3 파일 직접 읽어서 반환 (CORS 문제 우회)
         try:
-            print(f"Fetching S3 object: s3://{S3_BUCKET}/{s3_key}")
-            
+            print(f"Fetching S3 object: s3://{bucket}/{s3_key}")
+
             # S3에서 파일 가져오기
-            response = s3_client.get_object(Bucket=S3_BUCKET, Key=s3_key)
+            response = s3_client.get_object(Bucket=bucket, Key=s3_key)
             file_content = response['Body'].read().decode('utf-8')
             
             # 모든 타입을 Lambda에서 직접 반환 (presigned URL 서명 문제 해결)
@@ -174,7 +199,7 @@ def handler(event, context):
                         'job_id': job_id,
                         'status': 'completed',
                         'data': result_data,
-                        's3_location': f's3://{S3_BUCKET}/{s3_key}'
+                        's3_location': f's3://{bucket}/{s3_key}'
                     })
                 }
             else:
@@ -192,7 +217,7 @@ def handler(event, context):
                         'job_id': job_id,
                         'status': 'completed',
                         'data': result_data,  # 데이터 직접 제공 (프론트엔드에서 blob URL 생성)
-                        's3_location': f's3://{S3_BUCKET}/{s3_key}'
+                        's3_location': f's3://{bucket}/{s3_key}'
                     })
                 }
             

--- a/lambda/hybridTool/getResults.py
+++ b/lambda/hybridTool/getResults.py
@@ -140,13 +140,13 @@ def handler(event, context):
         
         # S3 경로 결정 (flattened: results/{endpoint}-{job_id}.json)
         if result_type == 'sensitivity-analysis':
-            s3_key = f"results/sensitivity-analysis-{job_id}.json"
+            s3_key = f"results/sensitivity/sensitivity-analysis-{job_id}.json"
         elif result_type == 'update-pfd':
-            s3_key = f"results/update-pfd-{job_id}.json"
+            s3_key = f"results/full/update-pfd-{job_id}.json"
         elif result_type == 'bbn-inference':
-            s3_key = f"results/results-{job_id}.json"
+            s3_key = f"results/bbn/results-{job_id}.json"
         else:  # full-analysis
-            s3_key = f"results/full-analysis-{job_id}.json"
+            s3_key = f"results/full/full-analysis-{job_id}.json"
         
         print(f"Checking S3 key: {s3_key}")
         

--- a/lambda/hybridTool/getResults.py
+++ b/lambda/hybridTool/getResults.py
@@ -143,6 +143,8 @@ def handler(event, context):
             s3_key = f"results/sensitivity-analysis-{job_id}.json"
         elif result_type == 'update-pfd':
             s3_key = f"results/update-pfd-{job_id}.json"
+        elif result_type == 'bbn-inference':
+            s3_key = f"results/results-{job_id}.json"
         else:  # full-analysis
             s3_key = f"results/full-analysis-{job_id}.json"
         

--- a/lambda/hybridTool/listBbnResults.py
+++ b/lambda/hybridTool/listBbnResults.py
@@ -5,15 +5,11 @@ Lambda Function: hybrid-tool-list-bbn-results
 - REST API 요청 수신 (GET /api/v1/results)
 - S3 버킷의 BBN 결과 JSON 파일 목록을 반환
 - key 쿼리 파라미터가 있으면 해당 파일의 내용을 반환
-
-스테이지 분기:
-- develop: BBN_RESULTS_BUCKET_DEV / BBN_RESULTS_PREFIX_DEV (기본: hybrid-tool-results / results/bbn/)
-- prod:    BBN_RESULTS_BUCKET     / BBN_RESULTS_PREFIX     (기본: bayesian-simulation-results-bucket / results/)
 """
 
 import json
 import os
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -21,13 +17,22 @@ from datetime import datetime
 
 s3_client = boto3.client("s3", region_name=os.environ.get("AWS_REGION", "ap-northeast-2"))
 
-# 프로덕션 기본값 (아직 구버킷 사용)
-DEFAULT_BUCKET_PROD = "bayesian-simulation-results-bucket"
-DEFAULT_PREFIX_PROD = "results/"
+# 현재 dev/prod 모두 hybrid-tool-results 사용
+DEFAULT_BUCKET = "hybrid-tool-results"
+DEFAULT_PREFIX = "results/bbn/"
+# 향후 prod 분기 확장용 변수 (현재 미사용)
+DEFAULT_BUCKET_PROD = os.environ.get("BBN_RESULTS_BUCKET", DEFAULT_BUCKET)
+DEFAULT_PREFIX_PROD = os.environ.get("BBN_RESULTS_PREFIX", DEFAULT_PREFIX)
 
-# 개발 기본값 (새 버킷 / 하위 폴더)
-DEFAULT_BUCKET_DEV = "hybrid-tool-results"
-DEFAULT_PREFIX_DEV = "results/bbn/"
+
+def _get_stage(event: Dict[str, Any]) -> str:
+    stage = (event.get("requestContext") or {}).get("stage", "")
+    if stage:
+        return stage
+    path = event.get("path", "")
+    if path.startswith("/develop/"):
+        return "develop"
+    return "prod"
 
 
 def _response(status_code: int, body: Dict[str, Any]) -> Dict[str, Any]:
@@ -49,30 +54,16 @@ def _json_serializer(obj):
     raise TypeError(f"Type {type(obj)} not serializable")
 
 
-def _get_stage(event: Dict[str, Any]) -> str:
-    stage = event.get("requestContext", {}).get("stage", "")
-    if stage:
-        return stage
-    path = event.get("path", "")
-    if path.startswith("/develop/"):
-        return "develop"
-    return "prod"
-
-
-def _get_bucket_and_prefix(stage: str) -> Tuple[str, str]:
-    if stage == "develop":
-        bucket = os.environ.get("BBN_RESULTS_BUCKET_DEV", DEFAULT_BUCKET_DEV)
-        prefix = os.environ.get("BBN_RESULTS_PREFIX_DEV", DEFAULT_PREFIX_DEV)
-    else:
-        bucket = os.environ.get("BBN_RESULTS_BUCKET", DEFAULT_BUCKET_PROD)
-        prefix = os.environ.get("BBN_RESULTS_PREFIX", DEFAULT_PREFIX_PROD)
-
+def _get_bucket_and_prefix():
+    bucket = os.environ.get("BBN_RESULTS_BUCKET", DEFAULT_BUCKET)
+    prefix = os.environ.get("BBN_RESULTS_PREFIX", DEFAULT_PREFIX)
     if prefix and not prefix.endswith("/"):
         prefix = prefix + "/"
     return bucket, prefix
 
 
-def _list_files(bucket: str, prefix: str, limit: int) -> Dict[str, Any]:
+def _list_files(limit: int) -> Dict[str, Any]:
+    bucket, prefix = _get_bucket_and_prefix()
     paginator = s3_client.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
@@ -119,7 +110,8 @@ def _list_files(bucket: str, prefix: str, limit: int) -> Dict[str, Any]:
     }
 
 
-def _get_file(bucket: str, prefix: str, key: str) -> Dict[str, Any]:
+def _get_file(key: str) -> Dict[str, Any]:
+    bucket, prefix = _get_bucket_and_prefix()
     normalized_key = key
     if prefix and not key.startswith(prefix):
         normalized_key = prefix + key
@@ -157,17 +149,13 @@ def handler(event, context):
         if http_method != "GET":
             return _response(405, {"message": f"Method {http_method} not allowed"})
 
-        stage = _get_stage(event)
-        bucket, prefix = _get_bucket_and_prefix(stage)
-        print(f"[CONFIG] stage={stage}, bucket={bucket}, prefix={prefix}")
-
         params: Optional[Dict[str, Any]] = event.get("queryStringParameters") or {}
         key = params.get("key") if isinstance(params, dict) else None
         limit_param = params.get("limit") if isinstance(params, dict) else None
 
         if key:
             try:
-                file_result = _get_file(bucket, prefix, key)
+                file_result = _get_file(key)
                 if "error" in file_result:
                     return _response(404, file_result)
                 return _response(200, file_result)
@@ -187,7 +175,7 @@ def handler(event, context):
         if limit > 500:
             limit = 500
 
-        result = _list_files(bucket, prefix, limit)
+        result = _list_files(limit)
         return _response(200, result)
 
     except Exception as exc:

--- a/lambda/hybridTool/listBbnResults.py
+++ b/lambda/hybridTool/listBbnResults.py
@@ -5,11 +5,15 @@ Lambda Function: hybrid-tool-list-bbn-results
 - REST API 요청 수신 (GET /api/v1/results)
 - S3 버킷의 BBN 결과 JSON 파일 목록을 반환
 - key 쿼리 파라미터가 있으면 해당 파일의 내용을 반환
+
+스테이지 분기:
+- develop: BBN_RESULTS_BUCKET_DEV / BBN_RESULTS_PREFIX_DEV (기본: hybrid-tool-results / results/bbn/)
+- prod:    BBN_RESULTS_BUCKET     / BBN_RESULTS_PREFIX     (기본: bayesian-simulation-results-bucket / results/)
 """
 
 import json
 import os
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -17,8 +21,13 @@ from datetime import datetime
 
 s3_client = boto3.client("s3", region_name=os.environ.get("AWS_REGION", "ap-northeast-2"))
 
-DEFAULT_BUCKET = "bayesian-simulation-results-bucket"
-DEFAULT_PREFIX = "results/bbn/"
+# 프로덕션 기본값 (아직 구버킷 사용)
+DEFAULT_BUCKET_PROD = "bayesian-simulation-results-bucket"
+DEFAULT_PREFIX_PROD = "results/"
+
+# 개발 기본값 (새 버킷 / 하위 폴더)
+DEFAULT_BUCKET_DEV = "hybrid-tool-results"
+DEFAULT_PREFIX_DEV = "results/bbn/"
 
 
 def _response(status_code: int, body: Dict[str, Any]) -> Dict[str, Any]:
@@ -40,17 +49,30 @@ def _json_serializer(obj):
     raise TypeError(f"Type {type(obj)} not serializable")
 
 
-def _get_bucket_and_prefix() -> (str, str):
-    bucket = os.environ.get("BBN_RESULTS_BUCKET", DEFAULT_BUCKET)
-    prefix = os.environ.get("BBN_RESULTS_PREFIX", DEFAULT_PREFIX)
-    # prefix는 비어있을 수 있으나, 있으면 '/'로 끝나도록 보정
+def _get_stage(event: Dict[str, Any]) -> str:
+    stage = event.get("requestContext", {}).get("stage", "")
+    if stage:
+        return stage
+    path = event.get("path", "")
+    if path.startswith("/develop/"):
+        return "develop"
+    return "prod"
+
+
+def _get_bucket_and_prefix(stage: str) -> Tuple[str, str]:
+    if stage == "develop":
+        bucket = os.environ.get("BBN_RESULTS_BUCKET_DEV", DEFAULT_BUCKET_DEV)
+        prefix = os.environ.get("BBN_RESULTS_PREFIX_DEV", DEFAULT_PREFIX_DEV)
+    else:
+        bucket = os.environ.get("BBN_RESULTS_BUCKET", DEFAULT_BUCKET_PROD)
+        prefix = os.environ.get("BBN_RESULTS_PREFIX", DEFAULT_PREFIX_PROD)
+
     if prefix and not prefix.endswith("/"):
         prefix = prefix + "/"
     return bucket, prefix
 
 
-def _list_files(limit: int) -> Dict[str, Any]:
-    bucket, prefix = _get_bucket_and_prefix()
+def _list_files(bucket: str, prefix: str, limit: int) -> Dict[str, Any]:
     paginator = s3_client.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
@@ -61,11 +83,10 @@ def _list_files(limit: int) -> Dict[str, Any]:
             if not key or key.endswith("/"):
                 continue
             if prefix and key.startswith(prefix):
-                relative_key = key[len(prefix) :]
+                relative_key = key[len(prefix):]
             else:
                 relative_key = key
             if relative_key.startswith("/"):
-                # 빈 경로 조각(//)이 포함된 객체는 제외
                 continue
             if "//" in relative_key:
                 continue
@@ -73,15 +94,14 @@ def _list_files(limit: int) -> Dict[str, Any]:
             if not relative_key:
                 continue
             if "/" in relative_key:
-                # 하위 "폴더"에 있는 객체는 목록에서 제외
+                # 하위 폴더 객체 제외
                 continue
             if not relative_key.lower().endswith(".json"):
                 continue
-            display_name = relative_key
             items.append(
                 {
                     "key": key,
-                    "name": display_name,
+                    "name": relative_key,
                     "size": obj.get("Size"),
                     "last_modified": obj.get("LastModified"),
                 }
@@ -99,8 +119,7 @@ def _list_files(limit: int) -> Dict[str, Any]:
     }
 
 
-def _get_file(key: str) -> Dict[str, Any]:
-    bucket, prefix = _get_bucket_and_prefix()
+def _get_file(bucket: str, prefix: str, key: str) -> Dict[str, Any]:
     normalized_key = key
     if prefix and not key.startswith(prefix):
         normalized_key = prefix + key
@@ -138,13 +157,17 @@ def handler(event, context):
         if http_method != "GET":
             return _response(405, {"message": f"Method {http_method} not allowed"})
 
+        stage = _get_stage(event)
+        bucket, prefix = _get_bucket_and_prefix(stage)
+        print(f"[CONFIG] stage={stage}, bucket={bucket}, prefix={prefix}")
+
         params: Optional[Dict[str, Any]] = event.get("queryStringParameters") or {}
         key = params.get("key") if isinstance(params, dict) else None
         limit_param = params.get("limit") if isinstance(params, dict) else None
 
         if key:
             try:
-                file_result = _get_file(key)
+                file_result = _get_file(bucket, prefix, key)
                 if "error" in file_result:
                     return _response(404, file_result)
                 return _response(200, file_result)
@@ -164,10 +187,9 @@ def handler(event, context):
         if limit > 500:
             limit = 500
 
-        result = _list_files(limit)
+        result = _list_files(bucket, prefix, limit)
         return _response(200, result)
 
     except Exception as exc:
         print(f"[ERROR] {exc}")
         return _response(500, {"message": f"Unexpected error: {exc}"})
-

--- a/lambda/hybridTool/listBbnResults.py
+++ b/lambda/hybridTool/listBbnResults.py
@@ -18,7 +18,7 @@ from datetime import datetime
 s3_client = boto3.client("s3", region_name=os.environ.get("AWS_REGION", "ap-northeast-2"))
 
 DEFAULT_BUCKET = "bayesian-simulation-results-bucket"
-DEFAULT_PREFIX = "results/"
+DEFAULT_PREFIX = "results/bbn/"
 
 
 def _response(status_code: int, body: Dict[str, Any]) -> Dict[str, Any]:

--- a/lambda/hybridTool/triggerSensitivityTask.py
+++ b/lambda/hybridTool/triggerSensitivityTask.py
@@ -121,6 +121,12 @@ def handler(event, context):
             bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
             bbn_input_s3_key = body.get('bbn_input_s3_key')
             bbn_job_id = body.get('bbn_job_id')
+            # bbn_job_id가 없으면 bbn_input_s3_key에서 파싱 (예: results/results-{jobId}.json)
+            if not bbn_job_id and bbn_input_s3_key:
+                import re
+                match = re.search(r'results-([^/]+)\.json$', bbn_input_s3_key)
+                if match:
+                    bbn_job_id = match.group(1)
             settings = body.get('settings', {})
             
             # 입력 검증

--- a/lambda/hybridTool/triggerSensitivityTask.py
+++ b/lambda/hybridTool/triggerSensitivityTask.py
@@ -227,7 +227,7 @@ def handler(event, context):
         if bbn_input_s3_bucket:
             environment_overrides.append({'name': 'BBN_INPUT_BUCKET', 'value': bbn_input_s3_bucket})
         if bbn_job_id:
-            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/prior-trace-{bbn_job_id}.nc'})
+            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/bbn/prior-trace-{bbn_job_id}.nc'})
 
         response = ecs_client.run_task(
             cluster=cluster_name,

--- a/lambda/hybridTool/triggerSensitivityTask.py
+++ b/lambda/hybridTool/triggerSensitivityTask.py
@@ -120,6 +120,7 @@ def handler(event, context):
             test_mode = body.get('test_mode', False)
             bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
             bbn_input_s3_key = body.get('bbn_input_s3_key')
+            bbn_job_id = body.get('bbn_job_id')
             settings = body.get('settings', {})
             
             # 입력 검증
@@ -219,6 +220,8 @@ def handler(event, context):
             environment_overrides.append({'name': 'BBN_INPUT_PATH', 'value': bbn_input_s3_key})
         if bbn_input_s3_bucket:
             environment_overrides.append({'name': 'BBN_INPUT_BUCKET', 'value': bbn_input_s3_bucket})
+        if bbn_job_id:
+            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/prior-trace-{bbn_job_id}.nc'})
 
         response = ecs_client.run_task(
             cluster=cluster_name,

--- a/lambda/hybridTool/triggerTask.py
+++ b/lambda/hybridTool/triggerTask.py
@@ -140,6 +140,7 @@ def handler(event, context):
         test_mode = body.get('test_mode', False)
         bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
         bbn_input_s3_key = body.get('bbn_input_s3_key')
+        bbn_job_id = body.get('bbn_job_id')
         settings = body.get('settings', {})
         
         # 입력 검증
@@ -273,6 +274,8 @@ def handler(event, context):
             environment_overrides.append({'name': 'BBN_INPUT_PATH', 'value': bbn_input_s3_key})
         if bbn_input_s3_bucket:
             environment_overrides.append({'name': 'BBN_INPUT_BUCKET', 'value': bbn_input_s3_bucket})
+        if bbn_job_id:
+            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/prior-trace-{bbn_job_id}.nc'})
 
         response = ecs_client.run_task(
             cluster=cluster_name,

--- a/lambda/hybridTool/triggerTask.py
+++ b/lambda/hybridTool/triggerTask.py
@@ -281,7 +281,7 @@ def handler(event, context):
         if bbn_input_s3_bucket:
             environment_overrides.append({'name': 'BBN_INPUT_BUCKET', 'value': bbn_input_s3_bucket})
         if bbn_job_id:
-            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/prior-trace-{bbn_job_id}.nc'})
+            environment_overrides.append({'name': 'PRIOR_TRACE_S3_KEY', 'value': f'results/bbn/prior-trace-{bbn_job_id}.nc'})
 
         response = ecs_client.run_task(
             cluster=cluster_name,

--- a/lambda/hybridTool/triggerTask.py
+++ b/lambda/hybridTool/triggerTask.py
@@ -141,6 +141,12 @@ def handler(event, context):
         bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
         bbn_input_s3_key = body.get('bbn_input_s3_key')
         bbn_job_id = body.get('bbn_job_id')
+        # bbn_job_id가 없으면 bbn_input_s3_key에서 파싱 (예: results/results-{jobId}.json)
+        if not bbn_job_id and bbn_input_s3_key:
+            import re
+            match = re.search(r'results-([^/]+)\.json$', bbn_input_s3_key)
+            if match:
+                bbn_job_id = match.group(1)
         settings = body.get('settings', {})
         
         # 입력 검증

--- a/scripts/deploy/hybridTool/deploy-hybridTool-task-definition-dev.sh
+++ b/scripts/deploy/hybridTool/deploy-hybridTool-task-definition-dev.sh
@@ -22,7 +22,8 @@ fi
 : "${AWS_REGION:=ap-northeast-2}"
 : "${AWS_PROFILE:=default}"
 : "${ECR_REPOSITORY:=hybrid-tool-pymc}"
-: "${DOCKER_IMAGE_TAG:=dev}"
+# Dev script always uses dev image tag (DOCKER_IMAGE_TAG_DEV takes priority)
+DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG_DEV:-dev}"
 : "${AWS_ACCOUNT_ID:?Set AWS_ACCOUNT_ID env var}"
 
 TASK_DEF_FILE="aws-configs/hybridTool-task-definition.json"

--- a/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
+++ b/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
@@ -71,7 +71,7 @@ ENV_VARS_JSON=$(cat <<EOF
     "SUBNET_IDS": "$SUBNET_IDS",
     "S3_BUCKET": "$S3_BUCKET",
     "JOBS_TABLE_NAME": "${JOBS_TABLE_NAME:-}",
-    "CONTAINER_NAME": "$CONTAINER_NAME"$([ -n "$CLUSTER_NAME_DEV" ] && echo ",\n    \"CLUSTER_NAME_DEV\": \"$CLUSTER_NAME_DEV\"" || echo "")$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && echo ",\n    \"HYBRID_TASK_DEFINITION_DEV\": \"$HYBRID_TASK_DEFINITION_DEV\"" || echo "")
+    "CONTAINER_NAME": "$CONTAINER_NAME"$([ -n "$CLUSTER_NAME_DEV" ] && printf ',\n    "CLUSTER_NAME_DEV": "%s"' "$CLUSTER_NAME_DEV" || true)$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && printf ',\n    "HYBRID_TASK_DEFINITION_DEV": "%s"' "$HYBRID_TASK_DEFINITION_DEV" || true)
   }
 }
 EOF

--- a/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
+++ b/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
@@ -34,6 +34,11 @@ fi
 # 선택적 환경 변수
 : "${JOBS_TABLE_NAME:=}"
 : "${CONTAINER_NAME:=hybrid-tool-container}"
+# BBN 결과 버킷: prod는 구버킷, dev는 신버킷
+: "${BBN_RESULTS_BUCKET:=bayesian-simulation-results-bucket}"
+: "${BBN_RESULTS_BUCKET_DEV:=hybrid-tool-results}"
+# getResults용 prod 버킷
+: "${S3_BUCKET_PROD:=bayesian-simulation-results-bucket}"
 
 # 개발 환경 변수 (선택적, 없으면 프로덕션 변수 사용)
 : "${CLUSTER_NAME_DEV:=}"
@@ -70,8 +75,11 @@ ENV_VARS_JSON=$(cat <<EOF
     "HYBRID_TASK_DEFINITION": "$HYBRID_TASK_DEFINITION",
     "SUBNET_IDS": "$SUBNET_IDS",
     "S3_BUCKET": "$S3_BUCKET",
+    "S3_BUCKET_PROD": "$S3_BUCKET_PROD",
     "JOBS_TABLE_NAME": "${JOBS_TABLE_NAME:-}",
-    "CONTAINER_NAME": "$CONTAINER_NAME"$([ -n "$CLUSTER_NAME_DEV" ] && printf ',\n    "CLUSTER_NAME_DEV": "%s"' "$CLUSTER_NAME_DEV" || true)$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && printf ',\n    "HYBRID_TASK_DEFINITION_DEV": "%s"' "$HYBRID_TASK_DEFINITION_DEV" || true)
+    "CONTAINER_NAME": "$CONTAINER_NAME",
+    "BBN_RESULTS_BUCKET": "$BBN_RESULTS_BUCKET",
+    "BBN_RESULTS_BUCKET_DEV": "$BBN_RESULTS_BUCKET_DEV"$([ -n "$CLUSTER_NAME_DEV" ] && printf ',\n    "CLUSTER_NAME_DEV": "%s"' "$CLUSTER_NAME_DEV" || true)$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && printf ',\n    "HYBRID_TASK_DEFINITION_DEV": "%s"' "$HYBRID_TASK_DEFINITION_DEV" || true)
   }
 }
 EOF

--- a/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
+++ b/scripts/deploy/hybridTool/set-hybridTool-lambda-env.sh
@@ -34,11 +34,8 @@ fi
 # 선택적 환경 변수
 : "${JOBS_TABLE_NAME:=}"
 : "${CONTAINER_NAME:=hybrid-tool-container}"
-# BBN 결과 버킷: prod는 구버킷, dev는 신버킷
-: "${BBN_RESULTS_BUCKET:=bayesian-simulation-results-bucket}"
-: "${BBN_RESULTS_BUCKET_DEV:=hybrid-tool-results}"
-# getResults용 prod 버킷
-: "${S3_BUCKET_PROD:=bayesian-simulation-results-bucket}"
+# BBN 결과 버킷 (dev/prod 모두 hybrid-tool-results 사용)
+: "${BBN_RESULTS_BUCKET:=hybrid-tool-results}"
 
 # 개발 환경 변수 (선택적, 없으면 프로덕션 변수 사용)
 : "${CLUSTER_NAME_DEV:=}"
@@ -75,11 +72,9 @@ ENV_VARS_JSON=$(cat <<EOF
     "HYBRID_TASK_DEFINITION": "$HYBRID_TASK_DEFINITION",
     "SUBNET_IDS": "$SUBNET_IDS",
     "S3_BUCKET": "$S3_BUCKET",
-    "S3_BUCKET_PROD": "$S3_BUCKET_PROD",
     "JOBS_TABLE_NAME": "${JOBS_TABLE_NAME:-}",
     "CONTAINER_NAME": "$CONTAINER_NAME",
-    "BBN_RESULTS_BUCKET": "$BBN_RESULTS_BUCKET",
-    "BBN_RESULTS_BUCKET_DEV": "$BBN_RESULTS_BUCKET_DEV"$([ -n "$CLUSTER_NAME_DEV" ] && printf ',\n    "CLUSTER_NAME_DEV": "%s"' "$CLUSTER_NAME_DEV" || true)$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && printf ',\n    "HYBRID_TASK_DEFINITION_DEV": "%s"' "$HYBRID_TASK_DEFINITION_DEV" || true)
+    "BBN_RESULTS_BUCKET": "$BBN_RESULTS_BUCKET"$([ -n "$CLUSTER_NAME_DEV" ] && printf ',\n    "CLUSTER_NAME_DEV": "%s"' "$CLUSTER_NAME_DEV" || true)$([ -n "$HYBRID_TASK_DEFINITION_DEV" ] && printf ',\n    "HYBRID_TASK_DEFINITION_DEV": "%s"' "$HYBRID_TASK_DEFINITION_DEV" || true)
   }
 }
 EOF

--- a/server_min/requirements.txt
+++ b/server_min/requirements.txt
@@ -30,6 +30,7 @@ scipy==1.16.2
 pymc==5.25.0
 pytensor==2.31.7
 arviz==0.22.0
+h5py>=3.8.0
 numpyro==0.19.0
 jax==0.8.0
 jaxlib==0.8.0


### PR DESCRIPTION
- PyMC-based BBN inference from OpenBUGS BBN inference
- Trace reuse for performance: After BBN inference, the full MCMC trace is saved. Downstream tasks (SST) load it via PRIOR_TRACE_S3_KEY to skip redundant sampling.
- S3 paths restructured: Results organized into results/bbn/, results/sensitivity/, results/full/ subfolders under hybrid-tool-results bucket.