### PR TITLE
Feature: failure-aware demand estimation (sensitivity analysis)

### DIFF
--- a/Dockers/HybridTool/run_sensitivity_analysis.py
+++ b/Dockers/HybridTool/run_sensitivity_analysis.py
@@ -6,6 +6,8 @@ Environment variables:
 - JOB_ID: Job identifier
 - PFD_GOAL: Target PFD value
 - CONFIDENCE_GOAL: Target confidence level
+- DEMAND: (optional, default 0) Number of tests already performed
+- FAILURES: (optional, default 0) Number of failures observed so far
 - S3_BUCKET: S3 bucket name for results
 - AWS_REGION: AWS region
 - PRIOR_TRACE_S3_KEY: (optional) S3 key of pre-computed prior trace (.nc)
@@ -39,21 +41,33 @@ def get_job_config() -> Dict[str, Any]:
     
     # Add Sensitivity Analysis specific environment variables
     config["CONFIDENCE_GOAL"] = float(os.environ.get("CONFIDENCE_GOAL", "0"))
-    
+    # Test history: demands already executed / failures observed so far
+    # (0/0 = plan from scratch, identical to the original behaviour)
+    config["DEMAND"] = int(os.environ.get("DEMAND", "0"))
+    config["FAILURES"] = int(os.environ.get("FAILURES", "0"))
+
     # Base validation
     validate_base_config(config)
-    
+
     # Sensitivity Analysis specific validation
     if config["CONFIDENCE_GOAL"] <= 0:
         raise ValueError("CONFIDENCE_GOAL must be a positive number")
     if config["CONFIDENCE_GOAL"] > 1.0:
         raise ValueError("CONFIDENCE_GOAL must be between 0 and 1 (e.g., 0.95)")
-    
+    if config["DEMAND"] < 0:
+        raise ValueError("DEMAND must be non-negative")
+    if config["FAILURES"] < 0:
+        raise ValueError("FAILURES must be non-negative")
+    if config["FAILURES"] > config["DEMAND"]:
+        raise ValueError("failures cannot exceed demand")
+
     config["PRIOR_TRACE_S3_KEY"] = os.environ.get("PRIOR_TRACE_S3_KEY")
 
     # Print configuration
     print_base_config(config)
     print(f"[CONFIG] CONFIDENCE_GOAL: {config['CONFIDENCE_GOAL']}")
+    print(f"[CONFIG] DEMAND: {config['DEMAND']}")
+    print(f"[CONFIG] FAILURES: {config['FAILURES']}")
     print(f"[CONFIG] DRAWS: {config['DRAWS']}")
     print(f"[CONFIG] TUNE: {config['TUNE']}")
     print(f"[CONFIG] CHAINS: {config['CHAINS']}")
@@ -68,6 +82,8 @@ def run_sensitivity_analysis(config: Dict[str, Any], bbn_data: Any) -> Dict[str,
     """Run Sensitivity Analysis"""
     pfd_goal = config["PFD_GOAL"]
     confidence_goal = config["CONFIDENCE_GOAL"]
+    tests_performed = config["DEMAND"]
+    failures = config["FAILURES"]
     draws = config["DRAWS"]
     tune = config["TUNE"]
     chains = config["CHAINS"]
@@ -87,22 +103,36 @@ def run_sensitivity_analysis(config: Dict[str, Any], bbn_data: Any) -> Dict[str,
     # 2. Sensitivity Analysis & Prior Metrics
     print("\n[STEP 2] Running sensitivity analysis...")
     
-    # Calculate required demand
-    num_tests = get_number_of_required_demand(
+    # Calculate the required TOTAL demand given the test history
+    # (Littlewood & Wright pfd-bound stopping rule: only the totals (N, j) matter)
+    num_tests, goal_already_achieved = get_number_of_required_demand(
         trace, pfd_goal=pfd_goal, confidence_goal=confidence_goal,
-        draws=draws, tune=tune, chains=chains, thin=thin
+        draws=draws, tune=tune, chains=chains, thin=thin,
+        failures=failures, tests_performed=tests_performed
     )
-    
+    num_tests = int(num_tests)
+
+    # Tests still to run = required total minus what has already been executed
+    # (the subtraction stays outside the model; only failures enters the likelihood)
+    additional_tests = 0 if goal_already_achieved else max(0, num_tests - tests_performed)
+
     # Calculate Prior PFD metrics (for context)
     prior_mean = trace.posterior["PFD"].mean().item()
     prior_conf = get_confidence(data=trace.posterior["PFD"], goal=pfd_goal)
-    
-    print(f"[STEP 2] Required number of tests: {int(num_tests)}")
+
+    print(f"[STEP 2] Required total number of tests: {num_tests}")
+    print(f"[STEP 2] Tests already performed: {tests_performed} (failures: {failures})")
+    print(f"[STEP 2] Additional tests required: {additional_tests}")
+    print(f"[STEP 2] Goal already achieved: {goal_already_achieved}")
     print(f"[STEP 2] Prior mean: {prior_mean}")
     print(f"[STEP 2] Prior confidence @goal: {prior_conf}")
-    
+
     return {
-        "num_tests": int(num_tests),
+        "num_tests": num_tests,
+        "additional_tests": additional_tests,
+        "tests_performed": tests_performed,
+        "failures": failures,
+        "goal_already_achieved": goal_already_achieved,
         "prior_mean": prior_mean,
         "prior_confidence": prior_conf,
     }
@@ -130,7 +160,9 @@ def build_completion_payload(
     payload = {
         "status": "completed",
         "job_id": config["JOB_ID"],
-        "num_tests": result_metrics["num_tests"]
+        "num_tests": result_metrics["num_tests"],
+        "additional_tests": result_metrics["additional_tests"],
+        "goal_already_achieved": result_metrics["goal_already_achieved"]
     }
     if config["TEST_OUTPUT_DIR"]:
         payload["local_path"] = s3_location
@@ -144,6 +176,10 @@ def get_test_mode_dummy(config: Dict[str, Any]) -> Dict[str, Any]:
     num_tests = 99999
     return {
         "num_tests": num_tests,
+        "additional_tests": max(0, num_tests - config["DEMAND"]),
+        "tests_performed": config["DEMAND"],
+        "failures": config["FAILURES"],
+        "goal_already_achieved": False,
         "prior_mean": config["PFD_GOAL"],
         "prior_confidence": config["CONFIDENCE_GOAL"],
     }

--- a/lambda/hybridTool/triggerSensitivityTask.py
+++ b/lambda/hybridTool/triggerSensitivityTask.py
@@ -60,7 +60,9 @@ def handler(event, context):
     요청 본문:
     {
         "pfd_goal": 0.0001,
-        "confidence_goal": 0.95
+        "confidence_goal": 0.95,
+        "demand": 0,      # (optional) 지금까지 수행한 테스트 수
+        "failures": 0     # (optional) 지금까지 관측된 실패 수
     }
     """
     # CORS Preflight 요청 처리 (OPTIONS 메서드)
@@ -117,6 +119,8 @@ def handler(event, context):
             
             pfd_goal = float(body.get('pfd_goal', 0))
             confidence_goal = float(body.get('confidence_goal', 0))
+            demand = int(body.get('demand', 0))
+            failures = int(body.get('failures', 0))
             test_mode = body.get('test_mode', False)
             bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
             bbn_input_s3_key = body.get('bbn_input_s3_key')
@@ -155,7 +159,19 @@ def handler(event, context):
                         'message': 'confidence_goal must be between 0 and 1'
                     })
                 }
-        
+
+            if demand < 0 or failures < 0 or failures > demand:
+                return {
+                    'statusCode': 400,
+                    'headers': {
+                        'Access-Control-Allow-Origin': '*',
+                        'Content-Type': 'application/json'
+                    },
+                    'body': json.dumps({
+                        'message': 'demand and failures must be non-negative, and failures cannot exceed demand'
+                    })
+                }
+
         except (ValueError, TypeError) as e:
             return {
                 'statusCode': 400,
@@ -187,6 +203,8 @@ def handler(event, context):
                         'createdAt': datetime.utcnow().isoformat(),
                         'pfdGoal': str(pfd_goal),
                         'confidenceGoal': str(confidence_goal),
+                        'demand': str(demand),
+                        'failures': str(failures),
                         'testMode': str(test_mode).lower(),
                         'bbnInputBucket': bbn_input_s3_bucket or '',
                         'bbnInputKey': bbn_input_s3_key or ''
@@ -214,6 +232,8 @@ def handler(event, context):
             {'name': 'JOB_ID', 'value': job_id},
             {'name': 'PFD_GOAL', 'value': str(pfd_goal)},
             {'name': 'CONFIDENCE_GOAL', 'value': str(confidence_goal)},
+            {'name': 'DEMAND', 'value': str(demand)},
+            {'name': 'FAILURES', 'value': str(failures)},
             {'name': 'S3_BUCKET', 'value': S3_BUCKET},
             {'name': 'AWS_REGION', 'value': AWS_REGION},
             {'name': 'TEST_MODE', 'value': 'true' if test_mode else 'false'},

--- a/server_min/bbn_inference/sensitivity_analysis.py
+++ b/server_min/bbn_inference/sensitivity_analysis.py
@@ -18,12 +18,26 @@ def demand_model_func(demand, observed_failures, pfd_trace):
 def get_confidence(data, goal):
     return np.count_nonzero(data <= goal) / data.size
 
-max_demand = 25000
 demand_interval = 200
 demand_start = 1
 N_RUNS = 3  # number of independent MCMC runs averaged per grid point (replaces the re-sampling loop)
 
-def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune, chains, thin):
+def get_max_demand(pfd_goal, confidence_goal, failures=0):
+    # Analytic bound on the total demands needed to reach confidence_goal with
+    # `failures` observed failures under a zero-information Beta(1,1) prior
+    # (chi-square few-failure bound; failures=0 reduces to ceil(-ln(1-c)/pfd_goal)).
+    # Replaces the fixed 25000 cap, which truncated the answer for failures >= 1.
+    return int(np.ceil(stats.chi2.ppf(confidence_goal, 2 * (failures + 1)) / (2 * pfd_goal)))
+
+def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune, chains, thin,
+                                  failures=0, tests_performed=0):
+    # Returns (required_total_demand, goal_already_achieved).
+    # `failures` enters the Binomial likelihood as observed evidence; `tests_performed`
+    # only moves the search start point — confidence is monotone in demand for fixed
+    # failures, so grid points below the demands already executed cannot contain the
+    # crossing (Littlewood & Wright 1997: only the totals (N, j) matter, not when
+    # the failures occurred).
+
     # filter out outliers for interpolation
     filtered_pfd_trace = filter_outsiders(trace.posterior["PFD"])
 
@@ -32,8 +46,14 @@ def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune,
     confidence_levels = []
     means = []
 
-    demand = demand_start
-    print("Sensitivity Analysis start!")
+    # Binomial likelihood requires demand >= failures
+    demand = max(demand_start, failures, tests_performed)
+    # keep the start point inside the search range so extreme tests_performed
+    # values still get one confidence evaluation
+    max_demand = max(get_max_demand(pfd_goal, confidence_goal, failures), demand)
+
+    print("Sensitivity Analysis start! (failures={}, tests_performed={}, max_demand={})".format(
+        failures, tests_performed, max_demand))
     while demand <= max_demand:
         print("number of demands: ", demand)
         demands.append(demand)
@@ -44,7 +64,7 @@ def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune,
         #  required demand to be under-estimated.)
         conf_samples = []
         for _ in range(N_RUNS):
-            demand_model = demand_model_func(demand=demand, observed_failures=0, pfd_trace=filtered_pfd_trace)
+            demand_model = demand_model_func(demand=demand, observed_failures=failures, pfd_trace=filtered_pfd_trace)
             demand_trace = run_sampling(model=demand_model, draws=draws, tune=tune, chains=chains, thin=thin)
             conf_samples.append(get_confidence(demand_trace.posterior["pfd_prior"], pfd_goal))
         confidence = float(np.mean(conf_samples))
@@ -54,7 +74,7 @@ def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune,
         means.append(demand_trace.posterior["pfd_prior"].mean().item())
         demand_traces.append(demand_trace)
         if confidence == confidence_goal:
-            return demand
+            return demand, (len(demands) == 1 and tests_performed >= 1)
         if confidence > confidence_goal:
             break
         demand += demand_interval
@@ -63,8 +83,10 @@ def get_number_of_required_demand(trace, pfd_goal, confidence_goal, draws, tune,
     # require calculation of number of demands
     for index, level in enumerate(confidence_levels):
         if level > confidence_goal and index == 0:
-            return demand_start
+            # goal already satisfied at the search start point; when demands were
+            # already executed this means no further testing is needed
+            return demands[0], tests_performed >= 1
         if level > confidence_goal and index >= 1:
-            return ((confidence_goal - confidence_levels[index-1]) / (level - confidence_levels[index-1]) * demand_interval) + demands[index-1]
+            return ((confidence_goal - confidence_levels[index-1]) / (level - confidence_levels[index-1]) * demand_interval) + demands[index-1], False
 
-    return max_demand
+    return max_demand, False


### PR DESCRIPTION
## 변경 내용
민감도 분석이 테스트 이력(기수행 테스트 수, 관측 실패 수)을 입력받아 실패를 반영한
총 demand와 추가 필요 테스트 수를 계산하도록 확장 (Littlewood & Wright 1997 pfd-bound stopping rule).
- get_number_of_required_demand: failures(Binomial 우도 반영), tests_performed(탐색 시작점) 파라미터 추가, (총 demand, 목표 기달성 여부) 반환
- max_demand 고정 25000 → 카이제곱 해석 상한으로 교체 (j=0: 29958, j=1: 47439) — 실패 반영 시 답이 25000에서 잘리는 문제 해결
- run_sensitivity_analysis: DEMAND/FAILURES env 추가, 결과에 additional_tests / goal_already_achieved 필드 추가
- triggerSensitivityTask lambda: body의 demand/failures 검증 후 ECS env로 전달
## 하위호환
demand/failures 미입력(0/0)이면 기존과 완전히 동일하게 동작