### PR TITLE
Feature: posterior predictive failure forecast for upcoming tests

### DIFF
--- a/Dockers/HybridTool/run_full_analysis.py
+++ b/Dockers/HybridTool/run_full_analysis.py
@@ -7,6 +7,8 @@ Environment variables:
 - PFD_GOAL: Target PFD value
 - CONFIDENCE_GOAL: Target confidence level
 - FAILURES: Observed number of failures
+- FORECAST_TESTS: (optional, default 0 = skip) Number of upcoming tests for the
+                  posterior predictive failure forecast
 - S3_BUCKET: S3 bucket name for results
 - AWS_REGION: AWS region
 - PRIOR_TRACE_S3_KEY: (optional) S3 key of pre-computed prior trace (.nc)
@@ -35,15 +37,17 @@ from bbn_inference.sensitivity_analysis import (
     demand_model_func,
 )
 from bbn_inference.runners.composite_model import run_composite_model
-from bbn_inference.bbn_utils import run_sampling
+from bbn_inference.bbn_utils import run_sampling, get_future_failure_prob
 
 
 def get_job_config() -> Dict[str, Any]:
     """Read and validate environment variables (Full Analysis specific)"""
     config = get_base_config()
-    
+
     # Add Full Analysis specific environment variables
     config["CONFIDENCE_GOAL"] = float(os.environ.get("CONFIDENCE_GOAL", "0"))
+    # Upcoming tests for the posterior predictive forecast (0 = skip)
+    config["FORECAST_TESTS"] = int(os.environ.get("FORECAST_TESTS", "0"))
     
     # FAILURES: required, must be provided (0 is a valid value, but None is not)
     failures_str = os.environ.get("FAILURES")
@@ -66,6 +70,8 @@ def get_job_config() -> Dict[str, Any]:
         raise ValueError("CONFIDENCE_GOAL must be a positive number")
     if config["FAILURES"] < 0:
         raise ValueError("FAILURES must be non-negative")
+    if not (0 <= config["FORECAST_TESTS"] <= 10_000_000):
+        raise ValueError("FORECAST_TESTS must be between 0 and 10,000,000")
     
     config["PRIOR_TRACE_S3_KEY"] = os.environ.get("PRIOR_TRACE_S3_KEY")
 
@@ -73,6 +79,7 @@ def get_job_config() -> Dict[str, Any]:
     print_base_config(config)
     print(f"[CONFIG] CONFIDENCE_GOAL: {config['CONFIDENCE_GOAL']}")
     print(f"[CONFIG] FAILURES: {config['FAILURES']}")
+    print(f"[CONFIG] FORECAST_TESTS: {config['FORECAST_TESTS']}")
     if config["DEMAND_REQUIRED"] is not None:
         print(f"[CONFIG] DEMAND_REQUIRED: {config['DEMAND_REQUIRED']} (reusing from sensitivity analysis)")
     else:
@@ -149,12 +156,23 @@ def run_full_analysis(config: Dict[str, Any], bbn_data: Any) -> Dict[str, Any]:
     pfd_output = [[str(demand), updated_mean]]
     print(f"[STEP 3] Demand={demand} -> PFD={updated_mean:.5g}, Confidence={last_conf:.4f}")
 
+    # Posterior predictive forecast: chance of seeing a failure in the upcoming tests
+    forecast_tests = config["FORECAST_TESTS"]
+    future_failure_prob = None
+    if forecast_tests > 0:
+        future_failure_prob = get_future_failure_prob(
+            updated_trace.posterior["pfd_prior"], forecast_tests
+        )
+        print(f"[STEP 3] P(>=1 failure in next {forecast_tests} tests): {future_failure_prob:.4f}")
+
     return {
         "demand_required": int(demand_required),
         "prior_mean": prior_mean,
         "prior_confidence": prior_conf,
         "pfd_output": pfd_output,
-        "final_confidence": last_conf
+        "final_confidence": last_conf,
+        "forecast_tests": forecast_tests,
+        "future_failure_prob": future_failure_prob
     }
 
 
@@ -181,6 +199,8 @@ def build_result_json(
         "output": {
             "mean_posterior_pfd": result_metrics["pfd_output"],
             "confidence": result_metrics["final_confidence"],
+            "forecast_tests": result_metrics["forecast_tests"],
+            "future_failure_prob": result_metrics["future_failure_prob"],
         },
     }
 
@@ -212,7 +232,9 @@ def get_test_mode_dummy(config: Dict[str, Any]) -> Dict[str, Any]:
         "prior_mean": config["PFD_GOAL"],
         "prior_confidence": config["CONFIDENCE_GOAL"],
         "pfd_output": [["100", 99999], ["200", 99999]],  # Dummy output structure
-        "final_confidence": 99999.0
+        "final_confidence": 99999.0,
+        "forecast_tests": config["FORECAST_TESTS"],
+        "future_failure_prob": 99999.0 if config["FORECAST_TESTS"] > 0 else None
     }
 
 

--- a/Dockers/HybridTool/run_update_pfd.py
+++ b/Dockers/HybridTool/run_update_pfd.py
@@ -7,6 +7,8 @@ Environment variables:
 - PFD_GOAL: Target PFD value
 - DEMAND: Number of tests
 - FAILURES: Observed number of failures
+- FORECAST_TESTS: (optional, default 0 = skip) Number of upcoming tests for the
+                  posterior predictive failure forecast
 - S3_BUCKET: S3 bucket name for results
 - AWS_REGION: AWS region
 
@@ -30,7 +32,7 @@ from bbn_inference.sensitivity_analysis import (
     demand_model_func,
 )
 from bbn_inference.runners.composite_model import run_composite_model
-from bbn_inference.bbn_utils import run_sampling
+from bbn_inference.bbn_utils import run_sampling, get_future_failure_prob
 
 
 def get_job_config() -> Dict[str, Any]:
@@ -40,10 +42,12 @@ def get_job_config() -> Dict[str, Any]:
     # Add Update PFD specific environment variables
     config["DEMAND"] = int(os.environ.get("DEMAND", "0"))
     config["FAILURES"] = int(os.environ.get("FAILURES", "0"))
-    
+    # Upcoming tests for the posterior predictive forecast (0 = skip)
+    config["FORECAST_TESTS"] = int(os.environ.get("FORECAST_TESTS", "0"))
+
     # Base validation
     validate_base_config(config)
-    
+
     # Update PFD specific validation
     if config["DEMAND"] <= 0:
         raise ValueError("DEMAND must be a positive number")
@@ -51,11 +55,14 @@ def get_job_config() -> Dict[str, Any]:
         raise ValueError("FAILURES must be non-negative")
     if config["FAILURES"] > config["DEMAND"]:
         raise ValueError("failures cannot exceed demand")
-    
+    if not (0 <= config["FORECAST_TESTS"] <= 10_000_000):
+        raise ValueError("FORECAST_TESTS must be between 0 and 10,000,000")
+
     # Print configuration
     print_base_config(config)
     print(f"[CONFIG] DEMAND: {config['DEMAND']}")
     print(f"[CONFIG] FAILURES: {config['FAILURES']}")
+    print(f"[CONFIG] FORECAST_TESTS: {config['FORECAST_TESTS']}")
     print(f"[CONFIG] DRAWS: {config['DRAWS']}")
     print(f"[CONFIG] TUNE: {config['TUNE']}")
     print(f"[CONFIG] CHAINS: {config['CHAINS']}")
@@ -100,15 +107,26 @@ def calculate_pfd_metrics(config: Dict[str, Any], bbn_data: Any) -> Dict[str, fl
     updated_conf = get_confidence(
         data=updated_trace.posterior["pfd_prior"], goal=pfd_goal
     )
-    
+
     print(f"[STEP 3] Updated PFD mean: {updated_pfd_mean}")
     print(f"[STEP 3] Updated confidence @goal: {updated_conf}")
-    
+
+    # Posterior predictive forecast: chance of seeing a failure in the upcoming tests
+    forecast_tests = config["FORECAST_TESTS"]
+    future_failure_prob = None
+    if forecast_tests > 0:
+        future_failure_prob = get_future_failure_prob(
+            updated_trace.posterior["pfd_prior"], forecast_tests
+        )
+        print(f"[STEP 3] P(>=1 failure in next {forecast_tests} tests): {future_failure_prob:.4f}")
+
     return {
         "updated_pfd": updated_pfd_mean,
         "updated_confidence": updated_conf,
         "prior_mean": prior_mean,
         "prior_confidence": before_conf,
+        "forecast_tests": forecast_tests,
+        "future_failure_prob": future_failure_prob,
     }
 
 
@@ -147,10 +165,12 @@ def build_completion_payload(
 def get_test_mode_dummy(config: Dict[str, Any]) -> Dict[str, float]:
     """Generate dummy data for test mode"""
     return {
-        "updated_pfd": 99999.0, 
+        "updated_pfd": 99999.0,
         "updated_confidence": 99999.0,
         "prior_mean": config["PFD_GOAL"],
         "prior_confidence": 0.95,
+        "forecast_tests": config["FORECAST_TESTS"],
+        "future_failure_prob": 99999.0 if config["FORECAST_TESTS"] > 0 else None,
     }
 
 

--- a/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
+++ b/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
@@ -725,11 +725,13 @@ export default function StatisticalPage() {
       return;
     }
 
-    // Posterior predictive forecast horizon: the tests still to run
-    // (additional tests from the plan, falling back to the total test count)
-    const forecastTests = additionalTests != null && additionalTests > 0
+    // Posterior predictive forecast horizon: the tests still to run.
+    // Only forecast mid-campaign (test history entered) — a plan-from-scratch
+    // posterior already assumes the full demand ran, so the horizon is ambiguous.
+    const hasTestHistory = sensitivityHistoryTests != null && sensitivityHistoryTests > 0;
+    const forecastTests = hasTestHistory && additionalTests != null && additionalTests > 0
       ? additionalTests
-      : (tests ?? 0);
+      : 0;
 
     try {
       // NOTE: trace_id is sent but ignored by HybridTool (stateless architecture)

--- a/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
+++ b/apps/frontend/src/features/statistical/components/StatisticalPage.tsx
@@ -725,6 +725,12 @@ export default function StatisticalPage() {
       return;
     }
 
+    // Posterior predictive forecast horizon: the tests still to run
+    // (additional tests from the plan, falling back to the total test count)
+    const forecastTests = additionalTests != null && additionalTests > 0
+      ? additionalTests
+      : (tests ?? 0);
+
     try {
       // NOTE: trace_id is sent but ignored by HybridTool (stateless architecture)
       // Test mode still makes actual API call but sends test_mode flag
@@ -733,6 +739,7 @@ export default function StatisticalPage() {
         confidence_goal: c,
         failures,
         demand_required: tests > 0 ? tests : undefined,
+        forecast_tests: forecastTests > 0 ? forecastTests : undefined,
         trace_id: traceId ?? undefined,
         test_mode: testMode || undefined,
         ...buildBbnPayload(),
@@ -1597,6 +1604,17 @@ export default function StatisticalPage() {
                   </span>
                 </div>
               </div>
+              {pfdUpdateResultData?.output?.future_failure_prob != null && (
+                <div css={cssObj.resultCardPriorRow} style={{ marginTop: 8 }}>
+                  <span>
+                    Failure risk in next{' '}
+                    {Number(pfdUpdateResultData.output.forecast_tests).toLocaleString()} tests:
+                  </span>
+                  <span style={{ fontWeight: 600, color: '#374151' }}>
+                    {(pfdUpdateResultData.output.future_failure_prob * 100).toFixed(1) + '%'}
+                  </span>
+                </div>
+              )}
               {pfdUpdateUsedDefaultBbn && (
                 <div css={cssObj.hintText} style={{ marginTop: 8 }}>
                   BBN input: NRC report data (default)

--- a/apps/frontend/src/shared/services/apiService.ts
+++ b/apps/frontend/src/shared/services/apiService.ts
@@ -139,11 +139,13 @@ export type SensitivityIn = {
 } & BbnInputOptions;
 
 export type PfdUpdateIn = {
-  pfd_goal: number; 
-  confidence_goal: number; 
-  failures: number; 
+  pfd_goal: number;
+  confidence_goal: number;
+  failures: number;
   demand_required?: number;
-  trace_id?: string | null; 
+  /** Posterior predictive forecast horizon: upcoming tests to assess failure risk over (0/omit = skip) */
+  forecast_tests?: number;
+  trace_id?: string | null;
   test_mode?: boolean;
   settings?: HybridToolSettings;
 } & BbnInputOptions;

--- a/lambda/hybridTool/triggerTask.py
+++ b/lambda/hybridTool/triggerTask.py
@@ -137,6 +137,7 @@ def handler(event, context):
         confidence_goal = float(body.get('confidence_goal', 0))
         failures_raw = body.get('failures')
         demand_required = body.get('demand_required')  # Optional: reuse from sensitivity analysis
+        forecast_tests = int(body.get('forecast_tests', 0))  # Optional: posterior predictive forecast horizon
         test_mode = body.get('test_mode', False)
         bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
         bbn_input_s3_key = body.get('bbn_input_s3_key')
@@ -264,6 +265,7 @@ def handler(event, context):
             {'name': 'PFD_GOAL', 'value': str(pfd_goal)},
             {'name': 'CONFIDENCE_GOAL', 'value': str(confidence_goal)},
             {'name': 'FAILURES', 'value': str(failures)},
+            {'name': 'FORECAST_TESTS', 'value': str(forecast_tests)},
             {'name': 'S3_BUCKET', 'value': S3_BUCKET},
             {'name': 'AWS_REGION', 'value': AWS_REGION},
             {'name': 'TEST_MODE', 'value': 'true' if test_mode else 'false'},

--- a/lambda/hybridTool/triggerUpdatePfdTask.py
+++ b/lambda/hybridTool/triggerUpdatePfdTask.py
@@ -120,6 +120,7 @@ def handler(event, context):
         pfd_goal = float(body.get('pfd_goal', 0))
         demand = int(body.get('demand', 0))
         failures = int(body.get('failures', 0))
+        forecast_tests = int(body.get('forecast_tests', 0))  # Optional: posterior predictive forecast horizon
         test_mode = body.get('test_mode', False)
         bbn_input_s3_bucket = body.get('bbn_input_s3_bucket')
         bbn_input_s3_key = body.get('bbn_input_s3_key')
@@ -231,6 +232,7 @@ def handler(event, context):
         
         environment_overrides = [
             {'name': 'TASK_TYPE', 'value': 'update_pfd'},
+            {'name': 'FORECAST_TESTS', 'value': str(forecast_tests)},
             {'name': 'JOB_ID', 'value': job_id},
             {'name': 'PFD_GOAL', 'value': str(pfd_goal)},
             {'name': 'DEMAND', 'value': str(demand)},

--- a/server_min/bbn_inference/bbn_utils.py
+++ b/server_min/bbn_inference/bbn_utils.py
@@ -105,3 +105,12 @@ def run_sampling(model, numpyro=False, draws=1000, tune=1000, chains=1, thin=1):
     print_summary(trace)
 
     return trace
+
+
+def get_future_failure_prob(data, num_future_demands):
+    # Posterior predictive P(at least one failure in the next num_future_demands
+    # demands), computed from posterior PFD samples: 1 - E[(1 - pfd)^m]
+    samples = np.clip(np.asarray(data).ravel(), 0.0, 1.0)
+    with np.errstate(divide="ignore"):
+        log_survival = num_future_demands * np.log1p(-samples)
+    return float(1.0 - np.mean(np.exp(log_survival)))


### PR DESCRIPTION
## 변경 내용
Update Probability 실행 시, 갱신된 사후 분포로 "앞으로 m번 테스트에서 실패를 1번 이상 볼 확률"을 계산해 결과에 표시
(Littlewood & Wright 예측기반 정지규칙의 보조 지표, 추가 MCMC 없이 기존 사후 샘플 재활용).
- forecast horizon m = 계획상 "추가 필요 테스트 수"(이력 없으면 총 테스트 수), 별도 입력 없이 자동 연동
- full-analysis / update-pfd 결과에 future_failure_prob 추가, Result summary에 "Failure risk in next N tests" 한 줄 표시
- m을 안 보내거나 0이면 계산을 건너뜀 — 기존 출력은 그대로